### PR TITLE
update for sonos group configuration spacing

### DIFF
--- a/sonos_coordinator_widget.yaml
+++ b/sonos_coordinator_widget.yaml
@@ -411,7 +411,7 @@ slots:
                                                                     action: variable
                                                                     actionVariable: =loop.groupInfo.thingUid
                                                                     actionVariableValue: "=vars[loop.groupInfo.thingUid] === undefined ? !loop.groupInfo.isInGroup : !vars[loop.groupInfo.thingUid]"
-                                                                    class: margin
+                                                                    
                                                                     iconF7: "=vars[loop.groupInfo.thingUid] === undefined ? (loop.groupInfo.isInGroup ? 'checkmark_square' : 'square') : (vars[loop.groupInfo.thingUid] ? 'checkmark_square' : 'square')"
                                                                     iconSize: 25px
                                                                 - component: Label


### PR DESCRIPTION
After installing all the speakers i noticed that the group configuration pop-up was taking all the screen and no way to scroll to select all the speakers and press the ok button so i changed that to make them without space to fit the popup